### PR TITLE
Set up publishing to PyPi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - jfc/packaging
   pull_request:
     branches:
     - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,10 @@ jobs:
         pip install -e .[tests]
         parserator train training/labeled.xml ilcs_parser
         pytest
+    - name: Print GitHub ref
+      run: echo $GITHUB_REF
   deploy:
-    if: github.event_name == 'push' && (startsWith(github.event.ref, 'refs/tags') || github.event.ref == 'jfc/packaging')
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || github.ref == 'jfc/packaging')
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -44,13 +46,13 @@ jobs:
         parserator train training/labeled.xml ilcs_parser
         python setup.py sdist bdist_wheel
     - name: Publish to test PyPI
-      if: github.event.ref == 'jfc/packaging'
+      if: github.ref == 'jfc/packaging'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
     - name: Publish to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - jfc/packaging
   pull_request:
     branches:
     - master
@@ -31,7 +30,7 @@ jobs:
     - name: Print GitHub ref
       run: echo $GITHUB_REF
   deploy:
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || endsWith(github.ref, 'jfc/packaging'))
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || endsWith(github.ref, 'master'))
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +45,7 @@ jobs:
         parserator train training/labeled.xml ilcs_parser
         python setup.py sdist bdist_wheel
     - name: Publish to test PyPI
-      if: endsWith(github.ref, 'jfc/packaging')
+      if: endsWith(github.ref, 'master')
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Print GitHub ref
       run: echo $GITHUB_REF
   deploy:
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || github.ref == 'jfc/packaging')
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || endsWith(github.ref, 'jfc/packaging'))
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +46,7 @@ jobs:
         parserator train training/labeled.xml ilcs_parser
         python setup.py sdist bdist_wheel
     - name: Publish to test PyPI
-      if: github.ref == 'jfc/packaging'
+      if: endsWith(github.ref, 'jfc/packaging')
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,6 @@ jobs:
         pip install -e .[tests]
         parserator train training/labeled.xml ilcs_parser
         pytest
-    - name: Print GitHub ref
-      run: echo $GITHUB_REF
   deploy:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || endsWith(github.ref, 'master'))
     needs: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         user: __token__
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,30 @@ jobs:
         pip install -e .[tests]
         parserator train training/labeled.xml ilcs_parser
         pytest
+  deploy:
+    if: github.event_name == 'push' && (startsWith(github.event.ref, 'refs/tags') || github.event.ref == 'jfc/packaging')
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Build distribution files
+      run: |
+        pip install --upgrade pip setuptools wheel
+        pip install -e .[tests]
+        parserator train training/labeled.xml ilcs_parser
+        python setup.py sdist bdist_wheel
+    - name: Publish to test PyPI
+      if: github.event.ref == 'jfc/packaging'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+    - name: Publish to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ cython_debug/
 # static files generated from Django application using `collectstatic`
 media
 static
+
+# CRFsuite
+*.crfsuite

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+README.md
+LICENSE

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,22 @@ except ImportError:
         "for installing setuptools"
     )
 
+
+def readme():
+    with open('README.md') as f:
+        return f.read()
+
+
 setup(
     version='0.0.0',
+    author='DataMade',
     url='https://github.com/datamade/ilcs-parser',
     description='Probabilistic parser for tagging data that references the Illinois Compiled Statutes (ILCS).',
+    long_description=readme(),
+    long_description_content_type='text/markdown',
     name='ilcs_parser',
     packages=['ilcs_parser'],
+    package_data={'ilcs_parser': ['learned_settings.crfsuite']},
     license='The MIT License: http://www.opensource.org/licenses/mit-license.php',
     install_requires=['python-crfsuite>=0.7',
                       'lxml'],
@@ -29,5 +39,5 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Information Analysis']
+        'Topic :: Scientific/Engineering :: Information Analysis'],
 )


### PR DESCRIPTION
## Overview

Configure the package to deploy to the test PyPI instance from `master` and the production PyPI instance from tags.

## Testing instructions

I tested that deployments would work by temporarily setting the workflow up to deploy to the test PyPI instance from this branch. [This action confirms it works](https://github.com/datamade/ilcs-parser/actions/runs/80991951) (note that the action technically failed because the deployment workflow did not want to overwrite an existing package, but the fact that we got that error is an indication that the authentication worked).