### PR TITLE
Improve parsing accuracy

### DIFF
--- a/ilcs_parser/__init__.py
+++ b/ilcs_parser/__init__.py
@@ -100,20 +100,25 @@ def tokenize(raw_string):
 
 
 def tokens2features(tokens):
+    # Record the number of tokens, since early tokens in longer strings tend to
+    # refer to Attempted charges.
+    num_tokens = len(tokens)
+    first_feature = tokenFeatures(tokens[0])
+    first_feature['num.tokens'] = num_tokens
+
     feature_sequence = [tokenFeatures(tokens[0])]
     previous_features = feature_sequence[-1].copy()
 
     for token in tokens[1:]:
         # set features for individual tokens (calling tokenFeatures)
         token_features = tokenFeatures(token)
+        token_features['num.tokens'] = num_tokens
         current_features = token_features.copy()
 
         # features for the features of adjacent tokens
         feature_sequence[-1]['next'] = current_features
         token_features['previous'] = previous_features
 
-        # DEFINE ANY OTHER FEATURES THAT ARE DEPENDENT UPON TOKENS BEFORE/AFTER
-        # for example, a feature for whether a certain character has appeared previously in the token sequence
         feature_sequence.append(token_features)
         previous_features = current_features
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -48,7 +48,7 @@ def test_tag_complex():
                 ('ActPrefix', '5'),
                 ('Section', '11'),
                 ('SubSection', '501 a 2'),
-                ('Attempted', 'att')
+                ('AttemptedSuffix', 'att')
             ]
         ),
         'Citation'

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -13,7 +13,7 @@ def test_parse():
 
 
 def test_tag():
-    assert ilcs_parser.tag('720-550//402-d') == (
+    assert ilcs_parser.tag('720-550//402-d') == ilcs_parser.CitationTag([
         OrderedDict(
             [
                 ('Chapter', '720'),
@@ -23,11 +23,11 @@ def test_tag():
             ]
         ),
         'Citation'
-    )
+    ])
 
 
 def test_tag_strip_parens():
-    assert ilcs_parser.tag('720-550/402(d)') == (
+    assert ilcs_parser.tag('720-550/402(d)') == ilcs_parser.CitationTag([
         OrderedDict(
             [
                 ('Chapter', '720'),
@@ -37,11 +37,11 @@ def test_tag_strip_parens():
             ]
         ),
         'Citation'
-    )
+    ])
 
 
 def test_tag_complex():
-    assert ilcs_parser.tag('625-5/11-501(a)(2) (tp337049) (att)') == (
+    assert ilcs_parser.tag('625-5/11-501(a)(2) (tp337049) (att)') == ilcs_parser.CitationTag([
         OrderedDict(
             [
                 ('Chapter', '625'),
@@ -52,11 +52,11 @@ def test_tag_complex():
             ]
         ),
         'Citation'
-    )
+    ])
 
 
 def test_attempted_prefix():
-    assert ilcs_parser.tag('720-5/8-4 625-5/11-501(a)(2)') == (
+    assert ilcs_parser.tag('720-5/8-4 625-5/11-501(a)(2)') == ilcs_parser.CitationTag([
         OrderedDict(
             [
                 ('AttemptedChapter', '720'),
@@ -70,4 +70,32 @@ def test_attempted_prefix():
             ]
         ),
         'Citation'
-    )
+    ])
+
+
+def test_tags_are_equal():
+    tag_a = ilcs_parser.tag('720-550/402-d')
+    tag_b = ilcs_parser.tag('720 550 402.d')
+    assert tag_a == tag_b
+    assert tag_a in [tag_b]
+
+
+def test_tags_are_not_equal():
+    tag_a = ilcs_parser.tag('720-550/402-d(a)(1)')
+    tag_b = ilcs_parser.tag('720 550 402.d')
+    assert tag_a != tag_b
+    assert tag_a not in [tag_b]
+
+
+def test_tags_are_equal_attempted():
+    tag_a = ilcs_parser.tag('720-5/8-4 625-5/11-501(a)(1)')
+    tag_b = ilcs_parser.tag('625-5/11-501.a.1 (att)')
+    assert tag_a == tag_b
+    assert tag_a in [tag_b]
+
+
+def test_tags_are_not_equal_attempted():
+    tag_a = ilcs_parser.tag('720-5/8-4 625-5/11-501(a)(1)')
+    tag_b = ilcs_parser.tag('625-5/11-501.a.1')
+    assert tag_a != tag_b
+    assert tag_a not in [tag_b]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -53,3 +53,21 @@ def test_tag_complex():
         ),
         'Citation'
     )
+
+
+def test_attempted_prefix():
+    assert ilcs_parser.tag('720-5/8-4 625-5/11-501(a)(2)') == (
+        OrderedDict(
+            [
+                ('AttemptedChapter', '720'),
+                ('AttemptedActPrefix', '5'),
+                ('AttemptedSection', '8'),
+                ('AttemptedSubSection', '4'),
+                ('Chapter', '625'),
+                ('ActPrefix', '5'),
+                ('Section', '11'),
+                ('SubSection', '501 a 2'),
+            ]
+        ),
+        'Citation'
+    )

--- a/tests/test_tokenizing.py
+++ b/tests/test_tokenizing.py
@@ -17,16 +17,16 @@ def test_spaces():
 
 
 def test_forward_slashes():
-    assert tokenize('foo/bar') == ['foo', '/bar']
+    assert tokenize('foo/bar') == ['foo', 'bar']
 
 
 def test_back_slashes():
-    assert tokenize('foo\\bar') == ['foo', '/bar']
+    assert tokenize('foo\\bar') == ['foo', 'bar']
 
 
 def test_parens():
-    assert tokenize('foobar(a)') == ['foobar', '(a)']
-    assert tokenize('foobar(a)(b)') == ['foobar', '(a)', '(b)']
+    assert tokenize('foobar(a)') == ['foobar', 'a']
+    assert tokenize('foobar(a)(b)') == ['foobar', 'a', 'b']
 
 
 def test_hyphens():
@@ -34,10 +34,10 @@ def test_hyphens():
 
 
 def test_strip_ilcs():
-    assert tokenize('720 ilcs 5/21') == ['720', '5', '/21']
+    assert tokenize('720 ilcs 5/21') == ['720', '5', '21']
 
 
 def test_strip_tlp_parens():
     assert tokenize('625-5/11-501(a)(2) (tp337049) (att)') == [
-        '625', '5', '/11', '501', '(a)', '(2)', '(att)'
+        '625', '5', '11', '501', 'a', '2', 'att'
     ]

--- a/training/labeled.xml
+++ b/training/labeled.xml
@@ -199,4 +199,5 @@
   <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Section>17</Section> <SubSection>3</SubSection></Citation>
   <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Section>18</Section> <SubSection>2a4</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>16</SubSection> <SubSection>a</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <ActPrefix>0</ActPrefix> <Section>402</Section> <SubSection>c</SubSection></Citation>
 </CitationCollection>

--- a/training/labeled.xml
+++ b/training/labeled.xml
@@ -1,187 +1,202 @@
 <CitationCollection>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <Section>303</Section> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>/5</ActPrefix> <Section>/24</Section> <SubSection>1a1</SubSection></Citation>
-  <Citation><Chapter>430</Chapter> <ActPrefix>65</ActPrefix> <Section>/3</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>130</ActPrefix> <Section>/2</Section> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/17</Section> <Section>41</Section> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>8</Section> <SubSection>4</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/5</Section> <SubSection>2</SubSection> <SubSection>(c)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>2</SubSection> <SubSection>(m)</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>21</SubSection></Citation>
-  <Citation><Chapter>3</Chapter> <ActPrefix>5</ActPrefix> <Section>14</Section> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>501</SubSection> <SubSection>(a)</SubSection> <SubSection>(2)</SubSection> <SubSection>(d)</SubSection> <SubSection>(1)</SubSection> <SubSection>(h)</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>6</SubSection> <SubSection>3</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>730</Chapter> <ActPrefix>150</ActPrefix> <Section>/150</Section> <SubSection>6</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/17</Section> <SubSection>24</SubSection> <SubSection>(1)</SubSection> <SubSection>(b)</SubSection> <SubSection>(1)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection> <SubSection>(a)</SubSection> <SubSection>(2)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/4</Section> <SubSection>(b)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/16</Section> <SubSection>4</SubSection> <SubSection>3</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>14</SubSection> <SubSection>1</SubSection> <SubSection>(a)</SubSection> <SubSection>(3)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/31</Section> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>4</SubSection> <SubSection>b</SubSection> <SubSection>6</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/26</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>725</Chapter> <ActPrefix>225</ActPrefix> <Section>/13</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/16</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>(x3)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection> <SubSection>(a)</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <Section>303</Section> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>24</Section> <SubSection>1a1</SubSection></Citation>
+  <Citation><Chapter>430</Chapter> <ActPrefix>65</ActPrefix> <Section>3</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>130</ActPrefix> <Section>2</Section> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>17</Section> <Section>41</Section> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <AttemptedSubSection>a</AttemptedSubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>5</Section> <SubSection>2</SubSection> <SubSection>c</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>2</SubSection> <SubSection>m</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>21</SubSection></Citation>
+  <Citation><Chapter>3</Chapter> <ActPrefix>5</ActPrefix> <Section>14</Section> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>501</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection> <SubSection>d</SubSection> <SubSection>1</SubSection> <SubSection>h</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>6</SubSection> <SubSection>3</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>730</Chapter> <ActPrefix>150</ActPrefix> <Section>150</Section> <SubSection>6</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>17</Section> <SubSection>24</SubSection> <SubSection>1</SubSection> <SubSection>b</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>4</Section> <SubSection>b</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>16</Section> <SubSection>4</SubSection> <SubSection>3</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>14</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>3</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>31</Section> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>4</SubSection> <SubSection>b</SubSection> <SubSection>6</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>26</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>725</Chapter> <ActPrefix>225</ActPrefix> <Section>13</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>16</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>x3</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection> <SubSection>a</SubSection></Citation>
   <Citation><Chapter>730</Chapter> <ActPrefix>5</ActPrefix> <Section>3</Section> <SubSection>3</SubSection> <SubSection>9</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>/401</Section> <SubSection>(c)</SubSection> <SubSection>(2)</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>401</Section> <SubSection>c</SubSection> <SubSection>2</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>17</Section> <SubSection>1b</SubSection> <SubSection>2</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>500</ActPrefix> <Section>/3</Section> <SubSection>5a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <Section>/3</Section> <SubSection>5</SubSection> <SubSection>c</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>500</ActPrefix> <Section>3</Section> <SubSection>5a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <Section>3</Section> <SubSection>5</SubSection> <SubSection>c</SubSection></Citation>
   <Citation><Chapter>25</Chapter> <ActPrefix>25</ActPrefix> <Section>61</Section></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>501</SubSection> <SubSection>(d)</SubSection> <SubSection>1</SubSection> <SubSection>(f)</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/4</Section> <SubSection>104a4</SubSection></Citation>
-  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>20</SubSection> <SubSection>e</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>1a</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>15</Chapter> <ActPrefix>335</ActPrefix> <Section>/14</Section> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>501</SubSection> <SubSection>d</SubSection> <SubSection>1</SubSection> <SubSection>f</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>104a4</SubSection></Citation>
+  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>20</SubSection> <SubSection>e</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>1a</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>15</Chapter> <ActPrefix>335</ActPrefix> <Section>14</Section> <SubSection>a</SubSection></Citation>
   <Citation><Chapter>9</Chapter> <ActPrefix>40</ActPrefix> <Section>250</Section></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>6</SubSection> <SubSection>3</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/5</Section> <SubSection>(e)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/160</Section> <SubSection>1</SubSection> <SubSection>(a)</SubSection> <SubSection>(4)</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/5</Section> <SubSection>102</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>9a1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/17</Section> <SubSection>10</SubSection> <SubSection>6</SubSection> <SubSection>c</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>3</SubSection> <SubSection>2a</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>42</Chapter> <ActPrefix>01</ActPrefix> <Section>(11)</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>14</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/10</Section> <SubSection>10</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/4</Section> <SubSection>102a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/28</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>600</Section> <SubSection>/3</SubSection> <SubSection>5a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>5</Section> <SubSection>e</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>160</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>4</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>5</Section> <SubSection>102</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>9a1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>17</Section> <SubSection>10</SubSection> <SubSection>6</SubSection> <SubSection>c</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>3</SubSection> <SubSection>2a</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>42</Chapter> <ActPrefix>01</ActPrefix> <Section>11</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>14</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>10</Section> <SubSection>10</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>102a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>28</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>600</Section> <SubSection>3</SubSection> <SubSection>5a</SubSection></Citation>
   <Citation><Chapter>4</Chapter> <ActPrefix>144</ActPrefix> <Section>190</Section></Citation>
-  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>16</SubSection> <SubSection>(a)</SubSection> <SubSection>(iii)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/4</Section> <SubSection>(d)</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>501c</SubSection> <SubSection>1</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/4</Section> <SubSection>104</SubSection> <SubSection>(a)</SubSection> <SubSection>(2)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>3</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/17</Section> <SubSection>2b6</SubSection></Citation>
+  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>16</SubSection> <SubSection>a</SubSection> <SubSection>iii</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>4</Section> <SubSection>d</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>501c</SubSection> <SubSection>1</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>104</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>3</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>17</Section> <SubSection>2b6</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>1a1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>646</ActPrefix> <Section>/60</Section> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/16a3a</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>30</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>/5</ActPrefix> <Section>4</Section> <SubSection>103a1</SubSection></Citation>
-  <Citation><Chapter>740</Chapter> <ActPrefix>90</ActPrefix> <ActPrefix>0</ActPrefix><Section>/5</Section></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>603</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/5</Section> <SubSection>2</SubSection> <SubSection>(e)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/5</Section> <SubSection>b</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>130</ActPrefix> <Section>/2</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/31</Section> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11501</Section> <SubSection>a</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/3</Section> <SubSection>707</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>646</ActPrefix> <Section>60</Section> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16a3a</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>30</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>103a1</SubSection></Citation>
+  <Citation><Chapter>740</Chapter> <ActPrefix>90</ActPrefix> <ActPrefix>0</ActPrefix><Section>5</Section></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>603</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>5</Section> <SubSection>2</SubSection> <SubSection>e</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>5</Section> <SubSection>b</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>130</ActPrefix> <Section>2</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>31</Section> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11501</Section> <SubSection>a</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>3</Section> <SubSection>707</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <Section>3</Section> <SubSection>5</SubSection></Citation>
-  <Citation><Chapter>9</Chapter> <ActPrefix>24</ActPrefix> <Section>010</Section> <Attempted>(con)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/110</Section> <SubSection>10a4</SubSection></Citation>
-  <Citation><Chapter>9</Chapter> <ActPrefix>8</ActPrefix> <Section>020</Section> <SubSection>(c)</SubSection> <SubSection>(1</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>1</SubSection> <SubSection>3</SubSection> <SubSection>(a)</SubSection></Citation>
+  <Citation><Chapter>9</Chapter> <ActPrefix>24</ActPrefix> <Section>010</Section> <AttemptedSuffix>con</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>110</Section> <SubSection>10a4</SubSection></Citation>
+  <Citation><Chapter>9</Chapter> <ActPrefix>8</ActPrefix> <Section>020</Section> <SubSection>c</SubSection> <SubSection>1</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>1</SubSection> <SubSection>3</SubSection> <SubSection>a</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>9</Section> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>250</ActPrefix> <Section>5</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/16</Section> <SubSection>3</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/6</Section> <SubSection>20e</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>3</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>6</Section> <SubSection>20e</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>4b</Section></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/10</Section> <Section>0</Section> <SubSection>/27</SubSection> <SubSection>2</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection> <SubSection>(a)</SubSection> <SubSection>(2)</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>21</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>603</SubSection> <SubSection>1</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>8</Chapter> <ActPrefix>12</ActPrefix> <Section>050</Section> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>204</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>16c1</SubSection></Citation>
-  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>20</SubSection></Citation>
-  <Citation><Chapter>725</Chapter> <ActPrefix>5</ActPrefix> <Section>/5</Section> <SubSection>/109</SubSection> <SubSection>2</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>/402</Section> <SubSection>a</SubSection> <SubSection>(7</SubSection> <SubSection>5)</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>2a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>/407b1</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/24</Section> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>30</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/11</Section> <SubSection>204</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>4</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>303</SubSection> <SubSection>d</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/8</Section> <SubSection>4</SubSection> <SubSection>//16</SubSection> <SubSection>1</SubSection> <SubSection>(a)</SubSection> <SubSection>(1)</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/18</Section> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>/8</SubSection> <SubSection>4</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>10</Section> <Section>0</Section> <SubSection>27</SubSection> <SubSection>2</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>4</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>21</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>603</SubSection> <SubSection>1</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>8</Chapter> <ActPrefix>12</ActPrefix> <Section>050</Section> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>204</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>16c1</SubSection></Citation>
+  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>20</SubSection></Citation>
+  <Citation><Chapter>725</Chapter> <ActPrefix>5</ActPrefix> <Section>5</Section> <SubSection>109</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>402</Section> <SubSection>a</SubSection> <SubSection>7</SubSection> <SubSection>5</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>2a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>407b1</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>24</Section> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>30</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>11</Section> <SubSection>204</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>4</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>303</SubSection> <SubSection>d</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>8</Section> <SubSection>4</SubSection> <SubSection>16</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>18</Section> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>8</SubSection> <SubSection>4</SubSection></Citation>
   <Citation><Chapter>6</Chapter> <ActPrefix>6</ActPrefix> <Section>2</Section> <SubSection>7b</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>4</SubSection> <SubSection>b</SubSection> <SubSection>6</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/21</Section> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/4</Section> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>25</SubSection> <SubSection>(b)</SubSection> <SubSection>(2)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>501</SubSection> <SubSection>d</SubSection> <SubSection>1</SubSection> <SubSection>b</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/8</Section> <SubSection>4</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>1</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>301</SubSection> <SubSection>1</SubSection> <SubSection>b</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>21</SubSection> <SubSection>6</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>303</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>25</SubSection> <SubSection>(a)</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>30a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>204</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>/401</Section> <SubSection>c</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>4</SubSection> <SubSection>b</SubSection> <SubSection>6</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>21</Section> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>4</Section> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>25</SubSection> <SubSection>b</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>501</SubSection> <SubSection>d</SubSection> <SubSection>1</SubSection> <SubSection>b</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>8</Section> <SubSection>4</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>1</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>301</SubSection> <SubSection>1</SubSection> <SubSection>b</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>21</SubSection> <SubSection>6</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>303</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>25</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>30a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>204</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>401</Section> <SubSection>c</SubSection> <SubSection>2</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>4</SubSection> <SubSection>1a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/31</Section> <SubSection>6c</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>31</Section> <SubSection>6c</SubSection></Citation>
   <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>402c</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/4a</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/402</Section> <SubSection>d</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>635</ActPrefix> <Section>/1</Section></Citation>
-  <Citation><Chapter>105</Chapter> <ActPrefix>5</ActPrefix> <Section>/26</Section> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/16a1a</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>/5</Section> <SubSection>d</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>3</SubSection> <SubSection>(a)</SubSection> <SubSection>(1)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/16</Section> <SubSection>(a)</SubSection> <SubSection>(1)</SubSection> <SubSection>(i)</SubSection></Citation>
-  <Citation><Chapter>740</Chapter> <ActPrefix>90</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/5</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/16</Section> <SubSection>28</SubSection> <SubSection>a</SubSection> <SubSection>8</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/19</Section> <SubSection>21</SubSection></Citation>
-  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>20</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <Section>/3</Section> <SubSection>5</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/31</Section> <SubSection>4</SubSection> <SubSection>(a)</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>709</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/19</Section> <SubSection>3</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/16a</Section> <SubSection>3</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>2</SubSection> <SubSection>(1)</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>/402</Section> <SubSection>c</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3a2</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>12</ActPrefix> <Section>3</Section> <SubSection>2</SubSection> <SubSection>(a)</SubSection> <SubSection>(1)</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/6016aiii</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>3</SubSection> <SubSection>(a)</SubSection> <SubSection>(3)</SubSection></Citation>
-  <Citation><Chapter>9</Chapter> <ActPrefix>8</ActPrefix> <Section>020</Section> <SubSection>(c)</SubSection> <SubSection>(1)</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>506</SubSection> <SubSection>(a)</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>4a</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>402</Section> <SubSection>d</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>635</ActPrefix> <Section>1</Section></Citation>
+  <Citation><Chapter>105</Chapter> <ActPrefix>5</ActPrefix> <Section>26</Section> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16a1a</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>550</ActPrefix> <Section>5</Section> <SubSection>d</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>a</SubSection> <SubSection>1</SubSection> <SubSection>i</SubSection></Citation>
+  <Citation><Chapter>740</Chapter> <ActPrefix>90</ActPrefix> <ActPrefix>0</ActPrefix> <Section>5</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>16</Section> <SubSection>28</SubSection> <SubSection>a</SubSection> <SubSection>8</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>19</Section> <SubSection>21</SubSection></Citation>
+  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>20</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <Section>3</Section> <SubSection>5</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>31</Section> <SubSection>4</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>709</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <ActPrefix>0</ActPrefix> <Section>19</Section> <SubSection>3</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16a</Section> <SubSection>3</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>2</SubSection> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>402</Section> <SubSection>c</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3a2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>12</ActPrefix> <Section>3</Section> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>6016aiii</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>3</SubSection></Citation>
+  <Citation><Chapter>9</Chapter> <ActPrefix>8</ActPrefix> <Section>020</Section> <SubSection>c</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>506</SubSection> <SubSection>a</SubSection></Citation>
   <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>104a</SubSection> <SubSection>5</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>303</SubSection> <SubSection>(d)</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>/401</Section> <SubSection>(a)</SubSection> <SubSection>(2)</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>1</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <Section>/3</Section> <SubSection>5</SubSection></Citation>
-  <Citation><Chapter>702</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>1</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>05</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>30</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/31</Section> <SubSection>6c</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/31</Section> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>404</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>301</SubSection> <SubSection>1</SubSection> <SubSection>b</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/4</Section> <SubSection>102</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>3</SubSection> <SubSection>(a)</SubSection> <SubSection>(2)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>154</ActPrefix> <Section>/10</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>1</SubSection> <SubSection>(h)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/135</Section> <SubSection>1</SubSection> <SubSection>1</SubSection> <SubSection>4</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>501</SubSection> <SubSection>(a)</SubSection> <SubSection>(1)</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>303</SubSection> <SubSection>(d)</SubSection></Citation>
-  <Citation><Chapter>430</Chapter> <ActPrefix>65</ActPrefix> <Section>/2</Section> <SubSection>(a)</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3a2</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/11</Section> <SubSection>501</SubSection> <SubSection>(a)</SubSection> <SubSection>(2)</SubSection> <Attempted>(att)</Attempted></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>112</SubSection></Citation>
-  <Citation><Chapter>725</Chapter> <ActPrefix>5</ActPrefix> <Section>/110</Section> <SubSection>104a4</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>303</SubSection> <SubSection>d</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>401</Section> <SubSection>a</SubSection> <SubSection>2</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <Section>3</Section> <SubSection>5</SubSection></Citation>
+  <Citation><Chapter>702</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>05</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>30</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>31</Section> <SubSection>6c</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>31</Section> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>404</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>301</SubSection> <SubSection>1</SubSection> <SubSection>b</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>102</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>154</ActPrefix> <Section>10</Section></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>1</SubSection> <SubSection>h</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>135</Section> <SubSection>1</SubSection> <SubSection>1</SubSection> <SubSection>4</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>501</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>303</SubSection> <SubSection>d</SubSection></Citation>
+  <Citation><Chapter>430</Chapter> <ActPrefix>65</ActPrefix> <Section>2</Section> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3a2</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>11</Section> <SubSection>501</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>112</SubSection></Citation>
+  <Citation><Chapter>725</Chapter> <ActPrefix>5</ActPrefix> <Section>110</Section> <SubSection>104a4</SubSection></Citation>
   <Citation><Chapter>8</Chapter> <ActPrefix>16</ActPrefix> <Section>060</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>4</SubSection> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/12</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/3</Section> <SubSection>707</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/16a</Section> <SubSection>3</SubSection> <SubSection>(c)</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>4</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>12</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>3</Section> <SubSection>707</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16a</Section> <SubSection>3</SubSection> <SubSection>c</SubSection></Citation>
   <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>104a3</SubSection></Citation>
   <Citation><Chapter>9</Chapter> <ActPrefix>52</ActPrefix> <Section>020</Section></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <ActPrefix>0</ActPrefix> <Section>/3</Section> <SubSection>5</SubSection> <SubSection>(a)</SubSection></Citation>
-  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>/4</Section> <SubSection>102a</SubSection> <SubSection>1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>/406</Section> <SubSection>2</SubSection> <SubSection>(a)</SubSection> <SubSection>93)</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/4</Section> <SubSection>104a1</SubSection></Citation>
-  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>/6</Section> <SubSection>16</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/21</Section> <SubSection>5</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>600</ActPrefix> <ActPrefix>0</ActPrefix> <Section>3</Section> <SubSection>5</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>102a</SubSection> <SubSection>1</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>406</Section> <SubSection>2</SubSection> <SubSection>a</SubSection> <SubSection>93</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>104a1</SubSection></Citation>
+  <Citation><Chapter>235</Chapter> <ActPrefix>5</ActPrefix> <Section>6</Section> <SubSection>16</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>21</Section> <SubSection>5</SubSection></Citation>
   <Citation><Chapter>625</Chapter> <ActPrefix>5</ActPrefix> <Section>4</Section> <SubSection>103a1</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/16</Section> <SubSection>16</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>16</SubSection></Citation>
   <Citation><Chapter>730</Chapter> <ActPrefix>150</ActPrefix> <Section>3</Section> <SubSection>a</SubSection></Citation>
-  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>/31</Section> <SubSection>4</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>31</Section> <SubSection>4</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Section>17</Section> <SubSection>3</SubSection></Citation>
+  <Citation><AttemptedChapter>20</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <AttemptedSubSection>a</AttemptedSubSection> <Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>18</Section> <SubSection>1</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <AttemptedSubSection>a</AttemptedSubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Section>19</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>18</Section> <SubSection>1</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4a</AttemptedSubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4a</AttemptedSubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>9</Section> <SubSection>1a</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>570</ActPrefix> <Section>401</Section> <SubSection>a</SubSection> <SubSection>2</SubSection> <SubSection>a</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>19</Section> <SubSection>3a</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>17</Section> <SubSection>3</SubSection> <SubSection>a</SubSection> <SubSection>2</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <AttemptedSubSection>a</AttemptedSubSection> <ActPrefix>5</ActPrefix> <Section>16a</Section> <SubSection>3</SubSection> <SubSection>a</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Section>17</Section> <SubSection>3</SubSection></Citation>
+  <Citation><AttemptedChapter>720</AttemptedChapter> <AttemptedActPrefix>5</AttemptedActPrefix> <AttemptedSection>8</AttemptedSection> <AttemptedSubSection>4</AttemptedSubSection> <Section>18</Section> <SubSection>2a4</SubSection></Citation>
+  <Citation><Chapter>720</Chapter> <ActPrefix>5</ActPrefix> <Section>16</Section> <SubSection>16</SubSection> <SubSection>a</SubSection> <AttemptedSuffix>att</AttemptedSuffix></Citation>
 </CitationCollection>


### PR DESCRIPTION
## Overview

Improve the parser's behavior with attempted charges that have the charge prefix `720-5/8-4`, add a bunch of new training data, and set up a test harness for computing accuracy statistics.

## Testing instructions

* Make sure tests pass.